### PR TITLE
More simply

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,32 @@
+name: Go
+
+on:
+  push:
+    branches: [ main ]
+    paths_ignore:
+      - README.md
+      - .gitignore
+  pull_request:
+    branches: [ main ]
+    paths_ignore:
+      - README.md
+      - .gitignore
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
+
+    - name: Build
+      run: go build
+
+    - name: Test
+      run: go test -v ./...

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,39 @@
+name: reviewdog
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths_ignore:
+      - README.md
+      - .gitignore
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+      - uses: reviewdog/action-golangci-lint@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          golangci_lint_flags: "--config=.golangci.yml"
+          reporter: github-pr-review
+          filter_mode: nofilter
+          fail_on_error: true
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+      - uses: reviewdog/action-staticcheck@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          filter_mode: nofilter
+          fail_on_error: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,7 @@
+linters:
+  disable-all: true
+  enable:
+    - gosec
+
+issues:
+  exclude-use-default: false

--- a/README.md
+++ b/README.md
@@ -56,3 +56,7 @@ Flags:
 ## License
 
 [MIT License](https://opensource.org/licenses/MIT).
+
+However The process of retrieving data from .netrc was borrowed from `src/cmd/go/internal/auth/netrc.go`.
+
+The license for this code part belongs to the BSD license of golang itself.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 `docker-loginex` is a Docker CLI plugins for slightly extending `docker login` command.
 
+Read the .netrc and uses that information to log in, if there is an entry corresponding to the specified server.
+
+If the entry for the specified server does not exist, it returns an error and exits.
+
 See https://github.com/docker/cli/issues/1534 for the Docker CLI plugins.
 
 ## How-to-use
@@ -11,26 +15,17 @@ $ mkdir -p ~/.docker/cli-plugins
 $ curl --output ~/.docker/cli-plugins/docker-loginex [Release URLs]
 $ chmod +x ~/.docker/cli-plugins/docker-loginex
 $ docker loginex --help
+A Docker CLI plugins for slightly extending `docker login` command.
 Log in to a Docker registry or cloud backend.
+If no server is specified, the default is defined by the daemon.
 See also help for `docker login`.
 
 Usage:
-  docker loginex [OPTIONS] [SERVER] [flags]
+  docker loginex [SERVER] [flags]
 
 Flags:
-  -h, --help              Help for login
-  -p, --password string   password
-      --password-stdin    Take the password from stdin
-  -u, --username string   username
+  -h, --help   help for docker
 ```
-
-## Feature
-
-* Add the ability to use `.netrc` to `docker login`.
-
-## ToDo
-
-* [ ] Implementation of `ghcr.io` subcommand.
 
 ## Reference
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Flags:
 
     https://text.baldanders.info/golang/no-need-go-homedir/
 
+* Goツールのリリースにおけるバージョニングについて
+
+    https://songmu.jp/riji/entry/2017-10-10-go-tool-version.html
+
 ## License
 
 [MIT License](https://opensource.org/licenses/MIT).

--- a/cmd/netrc.go
+++ b/cmd/netrc.go
@@ -50,7 +50,7 @@ func parseNetrc(data string) []netrcLine {
 			case "machine":
 				l = netrcLine{machine: f[i+1]}
 			case "default":
-				break
+				goto D
 			case "login":
 				l.login = f[i+1]
 			case "password":
@@ -67,6 +67,7 @@ func parseNetrc(data string) []netrcLine {
 			}
 		}
 
+	D:
 		if i < len(f) && f[i] == "default" {
 			// “There can be only one default token, and it must be after all machine tokens.”
 			break

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,7 @@ type dockerCliPluginMetadata struct {
 	SchemaVersion    string
 	Vendor           string
 	Version          string
+	Revision         string
 	ShortDescription string
 	URL              string
 }
@@ -23,7 +24,8 @@ type dockerCliPluginMetadata struct {
 var metadata dockerCliPluginMetadata = dockerCliPluginMetadata{
 	SchemaVersion:    "0.1.0",
 	Vendor:           "msfukui",
-	Version:          "unreleased",
+	Version:          version,
+	Revision:         revision,
 	ShortDescription: "Slightly extending `docker login` command",
 	URL:              "https://github.com/msfukui/docker-loginex",
 }
@@ -41,8 +43,9 @@ type loginInfo struct {
 }
 
 var rootCmd = &cobra.Command{
-	Use:   "docker loginex [SERVER]",
-	Short: "A Docker CLI plugins for slightly extending `docker login` command.",
+	Use:     "docker loginex [SERVER]",
+	Version: version,
+	Short:   "A Docker CLI plugins for slightly extending `docker login` command.",
 	Long: "A Docker CLI plugins for slightly extending `docker login` command.\n" +
 		"Log in to a Docker registry or cloud backend.\n" +
 		"If no server is specified, the default is defined by the daemon.\n" +
@@ -51,8 +54,7 @@ var rootCmd = &cobra.Command{
 		if len(args) > 0 {
 			if args[0] == "docker-cli-plugin-metadata" {
 				// Return metadata as a requirement of Docker CLI pligins.
-				v := getDockerCliPluginMetadata()
-				j, _ := json.Marshal(v)
+				j, _ := json.Marshal(getDockerCliPluginMetadata())
 				fmt.Println(string(j))
 				return nil
 			} else if args[0] == "loginex" {
@@ -75,6 +77,8 @@ func Execute() {
 }
 
 func init() {
+	v := "docker-loginex version: " + version + " (rev: " + revision + ")\n"
+	rootCmd.SetVersionTemplate(v)
 }
 
 func getDockerCliPluginMetadata() dockerCliPluginMetadata {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"github.com/spf13/cobra"
 	"io"
@@ -10,6 +11,22 @@ import (
 	"runtime"
 	"strings"
 )
+
+type dockerCliPluginMetadata struct {
+	SchemaVersion    string
+	Vendor           string
+	Version          string
+	ShortDescription string
+	URL              string
+}
+
+var metadata dockerCliPluginMetadata = dockerCliPluginMetadata{
+	SchemaVersion:    "0.1.0",
+	Vendor:           "msfukui",
+	Version:          "unreleased",
+	ShortDescription: "Slightly extending `docker login` command",
+	URL:              "https://github.com/msfukui/docker-loginex",
+}
 
 type loginOptions struct {
 	serverAddress string
@@ -32,9 +49,17 @@ var rootCmd = &cobra.Command{
 		"See also help for `docker login`.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) > 0 {
-			if args[0] == "loginex" {
-				// Judged that it was executed from the docker subcommand.
-				options.serverAddress = args[1]
+			if args[0] == "docker-cli-plugin-metadata" {
+				// Return metadata as a requirement of Docker CLI pligins.
+				v := getDockerCliPluginMetadata()
+				j, _ := json.Marshal(v)
+				fmt.Println(string(j))
+				return nil
+			} else if args[0] == "loginex" {
+				// Judged to be called as a subcommand of docker/cli.
+				if len(args) > 1 {
+					options.serverAddress = args[1]
+				}
 			} else {
 				options.serverAddress = args[0]
 			}
@@ -50,6 +75,10 @@ func Execute() {
 }
 
 func init() {
+}
+
+func getDockerCliPluginMetadata() dockerCliPluginMetadata {
+	return metadata
 }
 
 func runLoginex(opts loginOptions) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -113,8 +113,12 @@ func verifyloginOptions(opts loginOptions) error {
 }
 
 func setloginInfo(opts loginOptions, info *loginInfo) error {
+	netrcOnce.Do(readNetrc)
+	if netrcErr != nil {
+		return netrcErr
+	}
+
 	info.server = opts.serverAddress
-	readNetrc()
 	for _, v := range netrc {
 		if v.machine == info.server {
 			info.username = v.login

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,7 +43,7 @@ type loginInfo struct {
 }
 
 var rootCmd = &cobra.Command{
-	Use:     "docker loginex [SERVER]",
+	Use:     "docker-loginex [SERVER]",
 	Version: version,
 	Short:   "A Docker CLI plugins for slightly extending `docker login` command.",
 	Long: "A Docker CLI plugins for slightly extending `docker login` command.\n" +

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -128,9 +128,8 @@ func setloginInfo(opts loginOptions, info *loginInfo) error {
 
 func runDockerLogin(login loginInfo) (string, error) {
 	var buf bytes.Buffer
-	var cmd *exec.Cmd
 
-	cmd = exec.Command("docker", "login", "--password-stdin", "--username", login.username, login.server)
+	cmd := exec.Command("docker", "login", "--password-stdin", "--username", login.username, login.server) // #nosec G204
 
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = &buf

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,5 @@
+package cmd
+
+const version = "0.0.1"
+
+var revision = "Devel"


### PR DESCRIPTION
Read the .netrc and uses that information to log in, if there is an entry corresponding to the specified server.

If the entry for the specified server does not exist, it returns an error and exits.

Options such as -u and -p available with the login command are not supported once.